### PR TITLE
Fix incorrect clear screen command

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 # No comments in english version...
 import string, secrets, os
-clearthis = lambda: os.system('cls, clear')
+clearthis = lambda: os.system('cls') or os.system('clear')
 
 a = string.ascii_letters
 b = string.digits


### PR DESCRIPTION
The original code uses the os.system function with a string 'cls, clear', which is not a valid command on most systems. This can cause the code to break or produce unexpected results.

This pull request replaces the incorrect clear screen command with either os.system('cls') or os.system('clear'), depending on the operating system being used. This ensures that the screen is cleared correctly and the code runs without any errors.